### PR TITLE
Render Donors List in Donations Page

### DIFF
--- a/apps/bcc3d.ca/_data/donors.yml
+++ b/apps/bcc3d.ca/_data/donors.yml
@@ -1,6 +1,6 @@
-- name: Jone Doe
-  amount: $400.00
-  date: April 5th, 2020
-- name: Jane Doe
-  amount: $400.00
-  date: April 5th, 2020
+- name: Rain City Games
+  amount: $950.34
+  date: "April 25th, 2020"
+- name: LNG Studios (Leon Ng)
+  amount: $5000.00
+  date: April 20th, 2020

--- a/apps/bcc3d.ca/_data/donors.yml
+++ b/apps/bcc3d.ca/_data/donors.yml
@@ -1,0 +1,6 @@
+- name: Jone Doe
+  amount: $400.00
+  date: April 5th, 2020
+- name: Jane Doe
+  amount: $400.00
+  date: April 5th, 2020

--- a/apps/bcc3d.ca/pages/donations.html
+++ b/apps/bcc3d.ca/pages/donations.html
@@ -62,9 +62,10 @@ permalink: /donations/
         We would like thank our direct financial contributors to the project:
       </p>
       <ul>
-        <li>DONOR #1</li>
-        <li>DONOR #2</li>
-      </ul> -->
+        {% for donor in site.data.donors %}
+        <li>{{donor.name}}</li>
+        {% endfor %}
+      </ul>-->
       <p>
         As we ramp into larger scale production to support our provincial and
         local health authorities, financial support is key as we are resource

--- a/apps/bcc3d.ca/pages/donations.html
+++ b/apps/bcc3d.ca/pages/donations.html
@@ -9,7 +9,7 @@ permalink: /donations/
   <h2>Donations</h2>
 
   <div class="row">
-    <div class="col-md-4 order-2">
+    <div class="col-md-4 order-2" style="max-height: 80vh;">
       <h5>Donation Links</h5>
 
       <ul class="list-group mb-4">
@@ -29,6 +29,17 @@ permalink: /donations/
             ><i class="fad fa-donate fa-fw"></i> Donate using GoFundMe</a
           >
         </li>
+      </ul>
+      <h5>Donors</h5>
+      <ul class="list-group mb-4 overflow-auto" style="max-height: 50%;">
+        {% for donor in site.data.donors %}
+        <li class="list-group-item">
+          <div>{{donor.name}}</div>
+          <div>
+            <b>{{donor.amount}}</b>
+          </div>
+        </li>
+        {% endfor %}
       </ul>
     </div>
     <div class="col-md-8">
@@ -57,15 +68,6 @@ permalink: /donations/
       <h5>
         Finances
       </h5>
-      <!-- dynamically load donors list from here -->
-      <!-- <p>
-        We would like thank our direct financial contributors to the project:
-      </p>
-      <ul>
-        {% for donor in site.data.donors %}
-        <li>{{donor.name}}</li>
-        {% endfor %}
-      </ul>-->
       <p>
         As we ramp into larger scale production to support our provincial and
         local health authorities, financial support is key as we are resource


### PR DESCRIPTION
This PR implemented rendering list of donors in the left panel according to the list of donors in `donors.yml`.

I think it makes sense to have donors rendered in the side panel rather than in the main body since we wouldn't want to have scrollbar in the middle of the donations page.

**Screenshot of the added donors list in Donations Page.**
![Screen Shot 2020-04-27 at 8 26 34 PM](https://user-images.githubusercontent.com/42555515/80444054-859fd200-88c5-11ea-8637-4e2f6096ad48.png)
