### PR TITLE
Let donors know their name will be on donor list

### DIFF
--- a/apps/bcc3d.ca/pages/donations.html
+++ b/apps/bcc3d.ca/pages/donations.html
@@ -30,6 +30,10 @@ permalink: /donations/
           >
         </li>
       </ul>
+      <p class="thin-copy">
+        If you send us a donation through e-transfer, we will add your name to
+        the donor list. If you would like to opt-out, please let us know!
+      </p>
       <h5>Donors</h5>
       <ul class="list-group mb-4 overflow-auto" style="max-height: 50%;">
         {% for donor in site.data.donors %}


### PR DESCRIPTION
This PR added simple text to let donors know their name will be on the donor list unless they wish to opt-out.