### PR TITLE
add systemd unit files and install script

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+cp ./systemd/* /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now bcc3d-live
+systemctl enable --now bcc3d-qa
+systemctl enable --now bcc3d-ssl-termination
+
+echo "systemd units installed and enabled"

--- a/install/systemd/bcc3d-live.service
+++ b/install/systemd/bcc3d-live.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=BCC3D Live Docker Compose Stack
+
+[Service]
+ExecStartPre=/opt/bin/docker-compose -f /home/core/live/docker-compose.yml down
+ExecStart=/opt/bin/docker-compose -f /home/core/live/docker-compose.yml up
+
+[Install]
+WantedBy=multi-user.target

--- a/install/systemd/bcc3d-qa.service
+++ b/install/systemd/bcc3d-qa.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=BCC3D Quality Assurance Docker Compose Stack
+
+[Service]
+ExecStartPre=/opt/bin/docker-compose -f /home/core/qa/docker-compose.yml down
+ExecStart=/opt/bin/docker-compose -f /home/core/qa/docker-compose.yml up
+
+[Install]
+WantedBy=multi-user.target

--- a/install/systemd/bcc3d-ssl-termination.service
+++ b/install/systemd/bcc3d-ssl-termination.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=BCC3D SSL termination service
+
+[Service]
+ExecStartPre=/opt/bin/docker-compose -f /home/core/live/apps/ssl/docker-compose.yml down
+ExecStart=/opt/bin/docker-compose -f /home/core/live/apps/ssl/docker-compose.yml up
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding systemd unit files to start the containers when the server restarts.

The `cloudinit` service has been disabled to prevent keys from being overwritten.